### PR TITLE
PS-3942 Snowflake constructor

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -24,7 +24,17 @@ class Config extends BaseConfig
     {
         try {
             $databaseConfig = $this->getValue(['authorization', 'workspace']);
+            $databaseConfig = array_intersect_key($databaseConfig, array_fill_keys([
+                'host',
+                'port',
+                'user',
+                'password',
+                'warehouse',
+                'database',
+                'schema',
+            ], true));
             $databaseConfig['clientSessionKeepAlive'] = true;
+
             return $databaseConfig;
         } catch (InvalidArgumentException $exception) {
             throw new ApplicationException('Missing authorization for workspace');

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -126,6 +126,18 @@ class ConfigTest extends TestCase
         new Config($configArray, $configDefinition);
     }
 
+    public function testDatabaseConfigDoesNotContainUnknownKeys(): void
+    {
+        $configArray = [
+            'authorization' => $this->getDatabaseConfig(),
+        ];
+        $configDefinition = new ConfigDefinition();
+
+        $config = new Config($configArray, $configDefinition);
+
+        self::assertArrayNotHasKey('unknownKey', $config->getDatabaseConfig());
+    }
+
     private function getDatabaseConfig(): array
     {
         return [
@@ -136,6 +148,7 @@ class ConfigTest extends TestCase
                 'schema' => 'xxx',
                 'user' => 'xxx',
                 'password' => 'xxx',
+                'unknownKey' => 'xxx',
             ],
         ];
     }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-3942

Use only specific part of config to instantiate Snowflake connection. We have added `account` property to Snowflake credentials (because of Snowpark) but our `Connection` class from Showflake adapter lib requires only specific properties.