### PR TITLE
CT-1185 keboola/table-backend-utils 2.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM php:8.1-cli
+FROM php:8.1-cli-buster
 
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG SNOWFLAKE_ODBC_VERSION=2.25.9
+ARG SNOWFLAKE_ODBC_VERSION=2.25.12
 ARG SNOWFLAKE_GPG_KEY=630D9F3CAB551AF3
 
 ENV LANGUAGE=en_US.UTF-8
@@ -35,6 +35,29 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& chmod +x /tmp/composer-install.sh \
 	&& /tmp/composer-install.sh
 
+# SNOWFLAKE
+COPY ./docker/snowflake/generic.pol /etc/debsig/policies/$SNOWFLAKE_GPG_KEY/generic.pol
+COPY ./docker/snowflake/simba.snowflake.ini /usr/lib/snowflake/odbc/lib/simba.snowflake.ini
+
+
+
+# snowflake - charset settings
+ENV LANG en_US.UTF-8
+
+RUN mkdir -p ~/.gnupg \
+    && chmod 700 ~/.gnupg \
+    && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+    && mkdir /usr/share/debsig/keyrings/$SNOWFLAKE_GPG_KEY \
+    && if ! gpg --keyserver hkp://keys.gnupg.net --recv-keys $SNOWFLAKE_GPG_KEY; then \
+        gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $SNOWFLAKE_GPG_KEY;  \
+    fi \
+    && gpg --export $SNOWFLAKE_GPG_KEY > /usr/share/debsig/keyrings/$SNOWFLAKE_GPG_KEY/debsig.gpg \
+    && curl https://sfc-repo.snowflakecomputing.com/odbc/linux/$SNOWFLAKE_ODBC_VERSION/snowflake-odbc-$SNOWFLAKE_ODBC_VERSION.x86_64.deb --output /tmp/snowflake-odbc.deb \
+    && debsig-verify /tmp/snowflake-odbc.deb \
+    && gpg --batch --delete-key --yes $SNOWFLAKE_GPG_KEY \
+    && dpkg -i /tmp/snowflake-odbc.deb \
+    && rm /tmp/snowflake-odbc.deb
+
 # Snowflake ODBC
 # https://github.com/docker-library/php/issues/103#issuecomment-353674490
 RUN set -ex; \
@@ -49,26 +72,6 @@ RUN set -ex; \
     docker-php-ext-configure odbc --with-unixODBC=shared,/usr; \
     docker-php-ext-install odbc; \
     docker-php-source delete
-
-## install snowflake drivers
-COPY ./docker/snowflake/generic.pol /etc/debsig/policies/$SNOWFLAKE_GPG_KEY/generic.pol
-ADD https://sfc-repo.azure.snowflakecomputing.com/odbc/linux/$SNOWFLAKE_ODBC_VERSION/snowflake-odbc-$SNOWFLAKE_ODBC_VERSION.x86_64.deb /tmp/snowflake-odbc.deb
-COPY ./docker/snowflake/simba.snowflake.ini /usr/lib/snowflake/odbc/lib/simba.snowflake.ini
-
-RUN mkdir -p ~/.gnupg \
-    && mkdir -p /etc/gnupg/ \
-    && chmod 700 ~/.gnupg \
-    && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
-    && echo "allow-weak-digest-algos" >> /etc/gnupg/gpg.conf \
-    && mkdir -p /usr/share/debsig/keyrings/$SNOWFLAKE_GPG_KEY \
-    && if ! gpg --keyserver hkp://keys.gnupg.net --recv-keys $SNOWFLAKE_GPG_KEY; then \
-           gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $SNOWFLAKE_GPG_KEY;  \
-       fi \
-    && gpg --export $SNOWFLAKE_GPG_KEY > /usr/share/debsig/keyrings/$SNOWFLAKE_GPG_KEY/debsig.gpg \
-    && debsig-verify /tmp/snowflake-odbc.deb \
-    && gpg --batch --delete-key --yes $SNOWFLAKE_GPG_KEY \
-    && dpkg -i /tmp/snowflake-odbc.deb \
-    && rm /tmp/snowflake-odbc.deb
 
 ## Composer - deps always cached unless changed
 # First copy only composer files

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,10 @@ ADD https://sfc-repo.azure.snowflakecomputing.com/odbc/linux/$SNOWFLAKE_ODBC_VER
 COPY ./docker/snowflake/simba.snowflake.ini /usr/lib/snowflake/odbc/lib/simba.snowflake.ini
 
 RUN mkdir -p ~/.gnupg \
+    && mkdir -p /etc/gnupg/ \
     && chmod 700 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+    && echo "allow-weak-digest-algos" >> /etc/gnupg/gpg.conf \
     && mkdir -p /usr/share/debsig/keyrings/$SNOWFLAKE_GPG_KEY \
     && if ! gpg --keyserver hkp://keys.gnupg.net --recv-keys $SNOWFLAKE_GPG_KEY; then \
            gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $SNOWFLAKE_GPG_KEY;  \

--- a/composer.lock
+++ b/composer.lock
@@ -1392,16 +1392,16 @@
         },
         {
             "name": "keboola/table-backend-utils",
-            "version": "2.0.1",
+            "version": "2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/php-table-backend-utils.git",
-                "reference": "c668dcb3c251520339397b1db44b52b773b55e44"
+                "reference": "273c93c03d735415fec5596df5ac7f58fa7eb01d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/php-table-backend-utils/zipball/c668dcb3c251520339397b1db44b52b773b55e44",
-                "reference": "c668dcb3c251520339397b1db44b52b773b55e44",
+                "url": "https://api.github.com/repos/keboola/php-table-backend-utils/zipball/273c93c03d735415fec5596df5ac7f58fa7eb01d",
+                "reference": "273c93c03d735415fec5596df5ac7f58fa7eb01d",
                 "shasum": ""
             },
             "require": {
@@ -1442,9 +1442,9 @@
             "description": "Package allows to import files to Snowflake from multiple cloud storages",
             "support": {
                 "issues": "https://github.com/keboola/php-table-backend-utils/issues",
-                "source": "https://github.com/keboola/php-table-backend-utils/tree/2.0.1"
+                "source": "https://github.com/keboola/php-table-backend-utils/tree/2.2.4"
             },
-            "time": "2023-04-21T09:00:24+00:00"
+            "time": "2023-11-16T12:03:55+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -5430,5 +5430,5 @@
         "ext-mbstring": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Nová verze povoluje víc jak 1200 slouců.
Taky sem udělal update ODBC, problém byl constraint php8.1-cli, protože sa použil novější debian.

https://keboolaglobal.slack.com/archives/C011BERCEBG/p1700177728678689