### PR TITLE
chore: update Snowflake ODBC driver to 3.10.0 and upgrade to Debian Trixie (AJDA-1918)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM php:8.4-cli-bullseye
+FROM php:8.4-cli-trixie
 
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG SNOWFLAKE_ODBC_VERSION=3.6.0
+ARG SNOWFLAKE_ODBC_VERSION=3.10.0
 ARG SNOWFLAKE_GPG_KEY=2A3149C82551A34A
 
 ENV LANGUAGE=en_US.UTF-8
@@ -47,7 +47,9 @@ ENV LANG en_US.UTF-8
 RUN mkdir -p ~/.gnupg \
     && chmod 700 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
-    && mkdir /usr/share/debsig/keyrings/$SNOWFLAKE_GPG_KEY \
+    && mkdir -p /etc/gnupg \
+    && echo "allow-weak-digest-algos" >> /etc/gnupg/gpg.conf \
+    && mkdir /usr/share/debsig/keyrings/$SNOWFLAKE_GPG_KEY\
     && if ! gpg --keyserver hkp://keys.gnupg.net --recv-keys $SNOWFLAKE_GPG_KEY; then \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $SNOWFLAKE_GPG_KEY;  \
     fi \
@@ -57,6 +59,19 @@ RUN mkdir -p ~/.gnupg \
     && gpg --batch --delete-key --yes $SNOWFLAKE_GPG_KEY \
     && dpkg -i /tmp/snowflake-odbc.deb \
     && rm /tmp/snowflake-odbc.deb
+
+RUN cat <<EOF > /etc/odbcinst.ini
+[ODBC Drivers]
+SnowflakeDSIIDriver=Installed
+
+[SnowflakeDSIIDriver]
+APILevel=1
+ConnectFunctions=YYY
+Description=Snowflake DSII
+Driver=/usr/lib/snowflake/odbc/lib/libSnowflake.so
+DriverODBCVer=${SNOWFLAKE_ODBC_VERSION}
+SQLLevel=1
+EOF
 
 # Snowflake ODBC
 # https://github.com/docker-library/php/issues/103#issuecomment-353674490


### PR DESCRIPTION
# chore: update Snowflake ODBC driver to 3.10.0 and upgrade to Debian Trixie (AJDA-1918)

## Summary

This PR implements the infrastructure updates specified in ticket AJDA-1918:

1. **Base image upgrade**: Updated from `php:8.4-cli-bullseye` to `php:8.4-cli-trixie` (Debian 11 → Debian 13)
2. **ODBC driver update**: Upgraded Snowflake ODBC driver from version 3.6.0 to 3.10.0
3. **GPG configuration**: Added `allow-weak-digest-algos` to `/etc/gnupg/gpg.conf` to support GPG key verification with the new driver package
4. **ODBC configuration**: Created `/etc/odbcinst.ini` file with proper Snowflake driver registration

These changes align the component with the reference implementation in `keboola/connection` repository and ensure compatibility with newer Snowflake driver versions.

### Notes
- PHP version remains at 8.4 as specified in the ticket requirements
- The `DriverODBCVer` in odbcinst.ini uses the `${SNOWFLAKE_ODBC_VERSION}` variable which will be interpolated during build
- SnowSQL is not used by this component, so no SnowSQL-related changes were made
- Lint checks (phpcs and phpstan) passed successfully

---

**Link to Devin run**: https://app.devin.ai/sessions/1450402e7e034b96befcaa78db07387b  
**Requested by**: Ondřej Jodas (ondrej.jodas@keboola.com) / @ondrajodas  
**Ticket**: AJDA-1918