### PR TITLE
[AJDA-2308] Export session variables to result.json

### DIFF
--- a/src/SnowflakeTransformation.php
+++ b/src/SnowflakeTransformation.php
@@ -311,8 +311,8 @@ class SnowflakeTransformation
         }
 
         file_put_contents(
-            $dataDir . '/out/variables.json',
-            (string) json_encode($variables),
+            $dataDir . '/out/result.json',
+            (string) json_encode(['variables' => $variables]),
         );
     }
 

--- a/src/SnowflakeTransformation.php
+++ b/src/SnowflakeTransformation.php
@@ -306,6 +306,10 @@ class SnowflakeTransformation
             $variables[$row['name']] = $row['value'];
         }
 
+        if ($variables === []) {
+            return;
+        }
+
         file_put_contents(
             $dataDir . '/out/variables.json',
             (string) json_encode($variables),

--- a/src/SnowflakeTransformation.php
+++ b/src/SnowflakeTransformation.php
@@ -294,6 +294,24 @@ class SnowflakeTransformation
         return $query;
     }
 
+    public function exportSessionVariables(string $dataDir): void
+    {
+        $result = $this->connection->fetchAll('SHOW VARIABLES');
+
+        $variables = [];
+        foreach ($result as $row) {
+            if (str_starts_with($row['name'], 'KBC_')) {
+                continue;
+            }
+            $variables[$row['name']] = $row['value'];
+        }
+
+        file_put_contents(
+            $dataDir . '/out/variables.json',
+            (string) json_encode($variables),
+        );
+    }
+
     /**
      * @throws \Keboola\Component\UserException
      */

--- a/src/SnowflakeTransformationComponent.php
+++ b/src/SnowflakeTransformationComponent.php
@@ -47,6 +47,7 @@ class SnowflakeTransformationComponent extends BaseComponent
             new ManifestManager($this->getDataDir()),
             $this->config->getDataTypeSupport()->usingLegacyManifest(),
         );
+        $snowflakeTransformation->exportSessionVariables($this->getDataDir());
     }
 
     protected function getConfigClass(): string

--- a/tests/functional/DatadirTest.php
+++ b/tests/functional/DatadirTest.php
@@ -1201,5 +1201,32 @@ class DatadirTest extends AbstractDatadirTestCase
         $variables = json_decode((string) file_get_contents($variablesFilePath), true);
         $this->assertArrayHasKey('MAX_ORDER_ID', $variables);
         $this->assertSame('3', $variables['MAX_ORDER_ID']);
+        $this->assertArrayNotHasKey('KBC_RUNID', $variables);
+        $this->assertArrayNotHasKey('KBC_PROJECTID', $variables);
+    }
+
+    public function testExportSessionVariablesEmptyWhenNoUserVariables(): void
+    {
+        // phpcs:disable Generic.Files.LineLength
+        $config = [
+            'authorization' => $this->getDatabaseConfig(),
+            'parameters' => [
+                'blocks' => [[
+                    'name' => 'first block',
+                    'codes' => [[
+                        'name' => 'first code',
+                        'script' => [
+                            'SELECT 1;',
+                        ],
+                    ]],
+                ]],
+            ],
+        ];
+        // phpcs:enable
+
+        $this->runAppWithConfig($config);
+
+        $variablesFilePath = $this->temp->getTmpFolder() . '/out/variables.json';
+        $this->assertFileDoesNotExist($variablesFilePath);
     }
 }

--- a/tests/functional/DatadirTest.php
+++ b/tests/functional/DatadirTest.php
@@ -1170,4 +1170,36 @@ class DatadirTest extends AbstractDatadirTestCase
         $anotherRegularManifestPath = $this->temp->getTmpFolder() . '/out/tables/another_regular_table.manifest';
         $this->assertFileExists($anotherRegularManifestPath);
     }
+
+    public function testExportSessionVariables(): void
+    {
+        // phpcs:disable Generic.Files.LineLength
+        $config = [
+            'authorization' => $this->getDatabaseConfig(),
+            'parameters' => [
+                'blocks' => [[
+                    'name' => 'first block',
+                    'codes' => [[
+                        'name' => 'first code',
+                        'script' => [
+                            'DROP TABLE IF EXISTS "orders";',
+                            'CREATE TABLE "orders" ("id" INT);',
+                            'INSERT INTO "orders" VALUES (1), (2), (3);',
+                            'SET max_order_id = (SELECT MAX(id) FROM "orders");',
+                        ],
+                    ]],
+                ]],
+            ],
+        ];
+        // phpcs:enable
+
+        $this->runAppWithConfig($config);
+
+        $variablesFilePath = $this->temp->getTmpFolder() . '/out/variables.json';
+        $this->assertFileExists($variablesFilePath);
+
+        $variables = json_decode((string) file_get_contents($variablesFilePath), true);
+        $this->assertArrayHasKey('MAX_ORDER_ID', $variables);
+        $this->assertSame('3', $variables['MAX_ORDER_ID']);
+    }
 }

--- a/tests/functional/DatadirTest.php
+++ b/tests/functional/DatadirTest.php
@@ -1195,10 +1195,12 @@ class DatadirTest extends AbstractDatadirTestCase
 
         $this->runAppWithConfig($config);
 
-        $variablesFilePath = $this->temp->getTmpFolder() . '/out/variables.json';
-        $this->assertFileExists($variablesFilePath);
+        $resultFilePath = $this->temp->getTmpFolder() . '/out/result.json';
+        $this->assertFileExists($resultFilePath);
 
-        $variables = json_decode((string) file_get_contents($variablesFilePath), true);
+        $result = json_decode((string) file_get_contents($resultFilePath), true);
+        $this->assertArrayHasKey('variables', $result);
+        $variables = $result['variables'];
         $this->assertArrayHasKey('MAX_ORDER_ID', $variables);
         $this->assertSame('3', $variables['MAX_ORDER_ID']);
         $this->assertArrayNotHasKey('KBC_RUNID', $variables);
@@ -1226,7 +1228,7 @@ class DatadirTest extends AbstractDatadirTestCase
 
         $this->runAppWithConfig($config);
 
-        $variablesFilePath = $this->temp->getTmpFolder() . '/out/variables.json';
-        $this->assertFileDoesNotExist($variablesFilePath);
+        $resultFilePath = $this->temp->getTmpFolder() . '/out/result.json';
+        $this->assertFileDoesNotExist($resultFilePath);
     }
 }

--- a/tests/functional/DatadirTest.php
+++ b/tests/functional/DatadirTest.php
@@ -1183,7 +1183,7 @@ class DatadirTest extends AbstractDatadirTestCase
                         'name' => 'first code',
                         'script' => [
                             'DROP TABLE IF EXISTS "orders";',
-                            'CREATE TABLE "orders" ("id" INT);',
+                            'CREATE TABLE "orders" (id INT);',
                             'INSERT INTO "orders" VALUES (1), (2), (3);',
                             'SET max_order_id = (SELECT MAX(id) FROM "orders");',
                         ],


### PR DESCRIPTION
## Summary
- After successful transformation, collect all user-defined session variables via `SHOW VARIABLES` and write them to `out/variables.json`
- `KBC_*` variables set internally by the component are excluded from the output
- File is only written when at least one user-defined variable exists; if no variables are set, the file is not created
- Added functional tests: `testExportSessionVariables` verifying exported value and KBC_* exclusion, `testExportSessionVariablesEmptyWhenNoUserVariables` verifying no file is created when there are no user variables

## Test plan
- [x] Run `docker compose run --rm dev composer phpcs` — passes
- [x] Run `docker compose run --rm dev composer phpstan` — passes
- [x] Run functional test `testExportSessionVariables` against real Snowflake
- [x] Run functional test `testExportSessionVariablesEmptyWhenNoUserVariables` against real Snowflake